### PR TITLE
Importlib dependency

### DIFF
--- a/django_medusa/renderers/__init__.py
+++ b/django_medusa/renderers/__init__.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-import importlib
+from django.utils import importlib
 from .base import BaseStaticSiteRenderer
 from .disk import DiskStaticSiteRenderer
 from .appengine import GAEStaticSiteRenderer


### PR DESCRIPTION
Django-medusa uses importlib, which is present in Python 2.7/3.1 standard libraries but not in older versions.  Use the version provided by Django, since it is already a dependency.
