### PR TITLE
Check if generated file was modified before uploading to S3

### DIFF
--- a/django_medusa/renderers/s3.py
+++ b/django_medusa/renderers/s3.py
@@ -97,7 +97,7 @@ def _s3_render_path(args):
         bucket.get_website_endpoint(),
         path
     )
-
+    temp_file.close()
     return [path, outpath]
 
 


### PR DESCRIPTION
I think it's kinda wasteful to upload all files to S3 on every ./manage staticsitegen run, so I refactored _s3render_path to check the md5 hash against the key's etag (if it exists). 

Boto's #compute_md5 method expects a file object, so the function creates an in-memory file using cStringIO, a faster StringIO. If you find any problems, I could switch it for an in-disk NamedRemporaryFile.
