### PR TITLE
Allow for medusa-specific AWS buckets

### DIFF
--- a/django_medusa/renderers/s3.py
+++ b/django_medusa/renderers/s3.py
@@ -33,7 +33,8 @@ def _get_bucket():
         aws_access_key_id=settings.AWS_ACCESS_KEY,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
     )
-    return conn.get_bucket(settings.AWS_STORAGE_BUCKET_NAME)
+    bucket = (settings.MEDUSA_AWS_STORAGE_BUCKET_NAME if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME else settings.AWS_STORAGE_BUCKET_NAME)
+    return conn.get_bucket(bucket)
 
 
 def _upload_to_s3(key, file):
@@ -127,7 +128,7 @@ class S3StaticSiteRenderer(BaseStaticSiteRenderer):
             aws_access_key_id=settings.AWS_ACCESS_KEY,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
         )
-        self.bucket = self.conn.get_bucket(settings.AWS_STORAGE_BUCKET_NAME)
+        self.bucket = (self.conn.get_bucket(settings.MEDUSA_AWS_STORAGE_BUCKET_NAME) if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME else self.conn.get_bucket(settings.AWS_STORAGE_BUCKET_NAME))
         self.bucket.configure_website("index.html", "500.html")
         self.server_root_path = self.bucket.get_website_endpoint()
 


### PR DESCRIPTION
Currently, Medusa uses the same config variables that other S3
utilities use. This means using the same S3 bucket for file uploads,
for instance, that Medusa would use for its static site. It's possible
that a Medusa user may want to specify one S3 bucket for her static
site and another for file storages, for instance.

This patch introduces an optional configuration variable called
MEDUSA_AWS_STORAGE_BUCKET_NAME. If this variable is set, Medusa will
use it instead of the standard S3 bucket. If there is no
MEDUSA_AWS_STORAGE_BUCKET_NAME set, then Medusa will fall back to the
standard AWS_STORAGE_BUCKET_NAME configuration variable.

This code uses conditional expressions, which requires Python 2.5 (
http://docs.python.org/whatsnew/2.5.html#pep-308-conditional-expressions
 ). Since Django 1.4 itself requires Python 2.5, that seems ok, but if
Medusa needs to support older versions of Python, the conditional
expressions can be rewritten as standard if statements.

I imagine this could be extended to allow for other custom AWS
credentials, e.g. MEDUSA_AWS_ACCESS_KEY but that scenario seems less
likely than the desire to have the static site in one bucket and user
uploaded files in another.
