### PR TITLE
Add static media collection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -166,17 +166,52 @@ paths that don't have an extension and are *not* HTML files (i.e.
 "/foo/json/", "/feeds/blog/", etc.), the mimetype from the "Content-Type" HTTP
 header will be manually defined for this URL in the `app.yaml` path.
 
+## Collecting static media
+Django Medusa will collect static files into the directory specified by [directory name to come] if you add:
+
+    MEDUSA_COLLECTSTATIC = True
+
+to your `settings.py`. Optionally, you may specify a list of patterns to exclude by adding:
+
+    MEDUSA_COLLECTSTATIC_IGNORE = ['admin', 'less']
+
+### Specifying the static media collection directory
+By default, static files will be collected to the directory specified by `STATIC_ROOT`. If you wish to provide a different directory, you may do so via a django-medusa specific settings file, in which you can override `STATIC_ROOT`:
+
+Given the directory structure of:
+
+    your_app/
+        build/ <- MEDUSA_DEPLOY_DIRECTORY
+
+        your_app/
+            settings.py
+            medusa_settings.py
+
+and the following values in `medusa_settings.py`:
+
+    import os
+    from .settings import *
+
+    STATIC_ROOT = os.path.join(MEDUSA_DEPLOY_DIRECTORY, 'static')
+
+you can now run:
+
+    $ python manage.py staticsitegen --settings=your_app.medusa_settings
+
+and static media will be collected to your django-medusa specific directory.
+
+
 ## Usage
 
-1. Install `django-medusa` into your python path (TODO: setup.py) and add
+1. Install `django-medusa` into your python path via pip: `$ pip install django-medusa` or download and run `python setup.py` and add
    `django_medusa` to `INSTALLED_APPS`.
-2. Select a renderer backend (currently: disk or s3) in your settings.
+2. Select a renderer backend (currently: disk or s3) and other options in your settings.
 2. Create renderer classes in `renderers.py` under the apps you want to render.
 3. `django-admin.py staticsitegen`
-4. ???
+4. Deploy the static version of your site
 5. Profit!
 
-#### Example
+### Example
 
 From the first example in the "**Renderer classes**" section, using the
 disk-based backend.

--- a/README.markdown
+++ b/README.markdown
@@ -167,7 +167,7 @@ paths that don't have an extension and are *not* HTML files (i.e.
 header will be manually defined for this URL in the `app.yaml` path.
 
 ## Collecting static media
-Django Medusa will collect static files into the directory specified by [directory name to come] if you add:
+Django Medusa will collect static files for you after the static site code is generated if you add:
 
     MEDUSA_COLLECTSTATIC = True
 

--- a/README.markdown
+++ b/README.markdown
@@ -173,7 +173,7 @@ Django Medusa will collect static files for you after the static site code is ge
 
 to your `settings.py`. Optionally, you may specify a list of patterns to exclude by adding:
 
-    MEDUSA_COLLECTSTATIC_IGNORE = ['admin', 'less']
+    MEDUSA_COLLECT_STATIC_IGNORE = ['admin', 'less']
 
 ### Specifying the static media collection directory
 By default, static files will be collected to the directory specified by `STATIC_ROOT`. If you wish to provide a different directory, you may do so via a django-medusa specific settings file, in which you can override `STATIC_ROOT`:

--- a/README.markdown
+++ b/README.markdown
@@ -207,8 +207,8 @@ and static media will be collected to your django-medusa specific directory.
    `django_medusa` to `INSTALLED_APPS`.
 2. Select a renderer backend (currently: disk or s3) and other options in your settings.
 2. Create renderer classes in `renderers.py` under the apps you want to render.
-3. `django-admin.py staticsitegen`
-4. Deploy the static version of your site
+3. `django-admin.py staticsitegen` (optionally provide a specific settings file)
+4. Deploy the static version of your site.
 5. Profit!
 
 ### Example

--- a/django_medusa/__init__.py
+++ b/django_medusa/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)
 
 
 def get_version():

--- a/django_medusa/__init__.py
+++ b/django_medusa/__init__.py
@@ -1,5 +1,6 @@
 VERSION = (0, 3, 0)
 
+
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])
     if VERSION[2]:

--- a/django_medusa/management/commands/staticsitegen.py
+++ b/django_medusa/management/commands/staticsitegen.py
@@ -3,7 +3,7 @@ from django.core.management import call_command
 
 from django_medusa.renderers import StaticSiteRenderer
 from django_medusa.utils import get_static_renderers
-from django_medusa.settings import (MEDUSA_COLLECTSTATIC_IGNORE,
+from django_medusa.settings import (MEDUSA_COLLECT_STATIC_IGNORE,
     MEDUSA_COLLECT_STATIC)
 
 
@@ -25,4 +25,4 @@ class Command(BaseCommand):
         if MEDUSA_COLLECT_STATIC:
             # collect static media for deployment
             call_command('collectstatic', interactive=False,
-                ignore_patterns=MEDUSA_COLLECTSTATIC_IGNORE)
+                ignore_patterns=MEDUSA_COLLECT_STATIC_IGNORE)

--- a/django_medusa/management/commands/staticsitegen.py
+++ b/django_medusa/management/commands/staticsitegen.py
@@ -1,6 +1,9 @@
 from django.core.management.base import BaseCommand
+from django.core.management import call_command
+
 from django_medusa.renderers import StaticSiteRenderer
 from django_medusa.utils import get_static_renderers
+from django_medusa.settings import MEDUSA_COLLECTSTATIC_IGNORE
 
 
 class Command(BaseCommand):
@@ -17,3 +20,6 @@ class Command(BaseCommand):
             r.generate()
 
         StaticSiteRenderer.finalize_output()
+
+        # collect static media for deployment
+        call_command('collectstatic', interactive=False, ignore_patterns=MEDUSA_COLLECTSTATIC_IGNORE)

--- a/django_medusa/management/commands/staticsitegen.py
+++ b/django_medusa/management/commands/staticsitegen.py
@@ -3,7 +3,8 @@ from django.core.management import call_command
 
 from django_medusa.renderers import StaticSiteRenderer
 from django_medusa.utils import get_static_renderers
-from django_medusa.settings import MEDUSA_COLLECTSTATIC_IGNORE
+from django_medusa.settings import (MEDUSA_COLLECTSTATIC_IGNORE,
+    MEDUSA_COLLECT_STATIC)
 
 
 class Command(BaseCommand):
@@ -21,5 +22,7 @@ class Command(BaseCommand):
 
         StaticSiteRenderer.finalize_output()
 
-        # collect static media for deployment
-        call_command('collectstatic', interactive=False, ignore_patterns=MEDUSA_COLLECTSTATIC_IGNORE)
+        if MEDUSA_COLLECT_STATIC:
+            # collect static media for deployment
+            call_command('collectstatic', interactive=False,
+                ignore_patterns=MEDUSA_COLLECTSTATIC_IGNORE)

--- a/django_medusa/renderers/appengine.py
+++ b/django_medusa/renderers/appengine.py
@@ -56,7 +56,7 @@ def _gae_render_path(args):
             ""
         )
         if ((not needs_ext) and path.endswith(STANDARD_EXTENSIONS))\
-        or (mimetype == "text/html"):
+            or (mimetype == "text/html"):
             # Either has obvious extension OR it's a regular HTML file.
             return None
         return "# req since this url does not end in an extension and also\n"\

--- a/django_medusa/renderers/s3.py
+++ b/django_medusa/renderers/s3.py
@@ -36,7 +36,10 @@ def _get_bucket():
         aws_access_key_id=settings.AWS_ACCESS_KEY,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
     )
-    bucket = (settings.MEDUSA_AWS_STORAGE_BUCKET_NAME if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME else settings.AWS_STORAGE_BUCKET_NAME)
+
+    bucket = settings.AWS_STORAGE_BUCKET_NAME
+    if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME:
+        bucket = settings.MEDUSA_AWS_STORAGE_BUCKET_NAME
     return conn.get_bucket(bucket)
 
 
@@ -131,7 +134,10 @@ class S3StaticSiteRenderer(BaseStaticSiteRenderer):
             aws_access_key_id=settings.AWS_ACCESS_KEY,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
         )
-        self.bucket = (self.conn.get_bucket(settings.MEDUSA_AWS_STORAGE_BUCKET_NAME) if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME else self.conn.get_bucket(settings.AWS_STORAGE_BUCKET_NAME))
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+        if settings.MEDUSA_AWS_STORAGE_BUCKET_NAME:
+            bucket_name = settings.MEDUSA_AWS_STORAGE_BUCKET_NAME
+        self.conn.get_bucket(bucket_name)
         self.bucket.configure_website("index.html", "500.html")
         self.server_root_path = self.bucket.get_website_endpoint()
 

--- a/django_medusa/settings.py
+++ b/django_medusa/settings.py
@@ -2,5 +2,7 @@ from django.conf import settings
 
 
 MEDUSA_COLLECTSTATIC_IGNORE = getattr(settings,
-    'MEDUSA_COLLECTSTATIC_IGNORE', []
-)
+    'MEDUSA_COLLECTSTATIC_IGNORE', [])
+
+MEDUSA_COLLECT_STATIC = getattr(settings,
+    'MEDUSA_COLLECT_STATIC', False)

--- a/django_medusa/settings.py
+++ b/django_medusa/settings.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 
-MEDUSA_COLLECTSTATIC_IGNORE = getattr(settings,
+MEDUSA_COLLECT_STATIC_IGNORE = getattr(settings,
     'MEDUSA_COLLECTSTATIC_IGNORE', [])
 
 MEDUSA_COLLECT_STATIC = getattr(settings,

--- a/django_medusa/settings.py
+++ b/django_medusa/settings.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+MEDUSA_COLLECTSTATIC_IGNORE = getattr(settings,
+    'MEDUSA_COLLECTSTATIC_IGNORE', []
+)

--- a/django_medusa/utils.py
+++ b/django_medusa/utils.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 import imp
-from django.conf import settings
 from importlib import import_module
 import sys
+
+from django.conf import settings
 
 
 def get_static_renderers():
@@ -45,7 +46,7 @@ def get_static_renderers():
             if hasattr(app_render_module, "renderers"):
                 renderers += getattr(app_render_module, module_name)
             else:
-                print("Skipping app '%s'... ('%s.renderers' does not contain "\
+                print("Skipping app '%s'... ('%s.renderers' does not contain "
                       "'renderers' var (list of render classes)" % (app, app))
         except AttributeError:
             print("Skipping app '%s'... (Error importing '%s.renderers')" % (

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,28 @@
 from setuptools import setup, find_packages
 
-install_requires = [
-    'django',
-]
-
-version = "0.3.0"
+try:
+    README = open('README').read()
+except:
+    README = None
 
 setup(
     name='django-medusa',
-    version=version,
+    version=__import__('django_medusa').__version__,
     description='A Django static website generator.',
+    include_package_data=True,
     author='Mike Tigas',  # update this as needed
     author_email='mike@tig.as',  # update this as needed
     url='https://github.com/mtigas/django-medusa/',
-    download_url='https://github.com/mtigas/django-medusa/releases/tag/v0.3.0',
+    download_url='https://github.com/mtigas/django-medusa',
     packages=find_packages(),
-    install_requires=install_requires,
+    install_requires=['django'],
     license='MIT',
+    long_description=README,
     keywords='django static staticwebsite staticgenerator publishing',
     classifiers=["Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules"],
+    zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,12 @@ install_requires = [
 
 version = "0.3.0"
 
-setup(name='django-medusa',
+setup(
+    name='django-medusa',
     version=version,
     description='A Django static website generator.',
-    author='Mike Tigas', # update this as needed
-    author_email='mike@tig.as', # update this as needed
+    author='Mike Tigas',  # update this as needed
+    author_email='mike@tig.as',  # update this as needed
     url='https://github.com/mtigas/django-medusa/',
     download_url='https://github.com/mtigas/django-medusa/releases/tag/v0.3.0',
     packages=find_packages(),
@@ -21,6 +22,5 @@ setup(name='django-medusa',
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Topic :: Software Development :: Libraries :: Python Modules"
-    ],
+        "Topic :: Software Development :: Libraries :: Python Modules"],
 )


### PR DESCRIPTION
## Work

 - Added static media collection as a post static generation step to django-medusa.
 - Added two additional settings related to static file collection:
  - MEDUSA_COLLECT_STATIC (defaults to False)
  - MEDUSA_COLLECT_STATIC_IGNORE (defaults to [])
 - Updated readme with detailed instructions to collect static media to facilitate deployments.
 - Updated setup.py to automaticaly pull in readme and version.