### PR TITLE
Deal with StreamingHttpResponse in disk renderer

### DIFF
--- a/django_medusa/renderers/disk.py
+++ b/django_medusa/renderers/disk.py
@@ -53,7 +53,11 @@ def _disk_render_path(args):
                 outpath += "index.html"
         print(outpath)
         with open(outpath, 'wb') as f:
-            f.write(resp.content)
+            if resp.streaming:
+                for chunk in resp.streaming_content:
+                    f.write(chunk)
+            else:
+                f.write(resp.content)
 
 
 class DiskStaticSiteRenderer(BaseStaticSiteRenderer):


### PR DESCRIPTION
StreamingHttpResponse does not have a content attribute, so medusa fails here.

Need to iterate over response.streaming_content if response is StreamingHttpResponse and save it otherwise save response.content