### PR TITLE
work with AppConfigs in INSTALLED_APPS

### DIFF
--- a/django_medusa/utils.py
+++ b/django_medusa/utils.py
@@ -23,9 +23,14 @@ def get_static_renderers():
 
     # INSTALLED_APPS that aren't the project itself (also ignoring this
     # django_medusa module)
+    try:
+        from django.apps import apps
+        installed_apps = [app.module.__name__ for app in apps.get_app_configs()]
+    except ImportError:  # Fallback for Django < 1.7
+        installed_apps = settings.INSTALLED_APPS
     modules_to_check += filter(
         lambda x: (x != "django_medusa") and (x != settings_module),
-        settings.INSTALLED_APPS
+        installed_apps
     )
 
     for app in modules_to_check:


### PR DESCRIPTION
Hi Mike,
I'm submitting this pull request because of trouble I had while using django medusa with Django 1.8. Django 1.7 added the concept of [applications](https://docs.djangoproject.com/en/1.8/ref/applications/) where you define an `AppConfig` class. You have the option of using a path to the class in `INSTALLED_APPS`, as explained in the docs:

>Of course, you can also tell your users to put 'rock_n_roll.apps.RockNRollConfig' in their INSTALLED_APPS setting. You can even provide several different AppConfig subclasses with different behaviors and allow your users to choose one via their INSTALLED_APPS setting.

This is a problem in `django_medusa.utils` because it assumes everything in `INSTALLED_APPS` is a module path, not a class path. I worked around this, keeping the code almost entirely the same by using the `django.apps.get_apps_config()` method to get a list of apps django has loaded from `INSTALLED_APPS` and getting the string name of the module from there. From what I can tell this should be backwards compatible with Django < 1.7 but I have not used it that way myself.