### PR TITLE
Use standart importlib instead of django.utils.importlib

### DIFF
--- a/django_medusa/renderers/__init__.py
+++ b/django_medusa/renderers/__init__.py
@@ -1,9 +1,10 @@
 from django.conf import settings
-from django.utils import importlib
+from importlib import import_module
 from .base import BaseStaticSiteRenderer
 from .disk import DiskStaticSiteRenderer
 from .appengine import GAEStaticSiteRenderer
 from .s3 import S3StaticSiteRenderer
+
 
 __all__ = ('BaseStaticSiteRenderer', 'DiskStaticSiteRenderer',
            'S3StaticSiteRenderer', 'GAEStaticSiteRenderer',
@@ -12,7 +13,7 @@ __all__ = ('BaseStaticSiteRenderer', 'DiskStaticSiteRenderer',
 
 def get_cls(renderer_name):
     mod_path, cls_name = renderer_name.rsplit('.', 1)
-    mod = importlib.import_module(mod_path)
+    mod = import_module(mod_path)
     return getattr(mod, cls_name)
 
 

--- a/django_medusa/renderers/__init__.py
+++ b/django_medusa/renderers/__init__.py
@@ -5,7 +5,6 @@ from .disk import DiskStaticSiteRenderer
 from .appengine import GAEStaticSiteRenderer
 from .s3 import S3StaticSiteRenderer
 
-
 __all__ = ('BaseStaticSiteRenderer', 'DiskStaticSiteRenderer',
            'S3StaticSiteRenderer', 'GAEStaticSiteRenderer',
            'StaticSiteRenderer')

--- a/django_medusa/utils.py
+++ b/django_medusa/utils.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from importlib import import_module
 import sys
 
-
 def get_static_renderers():
     module_name = 'renderers'
     renderers = []

--- a/django_medusa/utils.py
+++ b/django_medusa/utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from importlib import import_module
 import sys
 
+
 def get_static_renderers():
     module_name = 'renderers'
     renderers = []


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9

> Features removed in 1.9
> - django.utils.importlib is removed.
